### PR TITLE
Added Support for Spark 2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val rootProjectName = settingKey[String]("Name of the root project")
 
 lazy val commonMetaInformationSettings = Seq(
   organization      := "de.frosner",
-  version           := "4.0.0-gamma-SNAPSHOT",
+  version           := "5.0.0-gamma-SNAPSHOT",
   scalaVersion      := "2.11.8",
   rootProjectName   := "spawncamping-dds"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val rootProjectName = settingKey[String]("Name of the root project")
 lazy val commonMetaInformationSettings = Seq(
   organization      := "de.frosner",
   version           := "4.0.0-gamma-SNAPSHOT",
-  scalaVersion      := "2.10.6",
+  scalaVersion      := "2.11.8",
   rootProjectName   := "spawncamping-dds"
 )
 

--- a/core/src/main/scala/de/frosner/dds/core/ScalaFunctions.scala
+++ b/core/src/main/scala/de/frosner/dds/core/ScalaFunctions.scala
@@ -4,7 +4,7 @@ import de.frosner.dds.servables._
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.ScalaReflection.Schema
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, CatalystTypeConvertersAdapter, ScalaReflection}
-import org.apache.spark.sql.catalyst.expressions.GenericMutableRow
+//import org.apache.spark.sql.catalyst.expressions.GenericMutableRow
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 

--- a/core/src/main/scala/de/frosner/dds/core/ScalaFunctions.scala
+++ b/core/src/main/scala/de/frosner/dds/core/ScalaFunctions.scala
@@ -4,7 +4,6 @@ import de.frosner.dds.servables._
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.ScalaReflection.Schema
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, CatalystTypeConvertersAdapter, ScalaReflection}
-//import org.apache.spark.sql.catalyst.expressions.GenericMutableRow
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 

--- a/core/src/main/scala/de/frosner/dds/core/SparkSqlFunctions.scala
+++ b/core/src/main/scala/de/frosner/dds/core/SparkSqlFunctions.scala
@@ -12,6 +12,8 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 
+import org.apache.spark.sql.types.StructType
+
 import de.frosner.dds.util.DataFrameUtils._
 
 object SparkSqlFunctions {
@@ -323,11 +325,15 @@ object SparkSqlFunctions {
       val nominalColumnStatistics = columnStatistics.nominalColumns
       val nominalFields = getNominalFields(dataFrame)
       val nominalServables = for ((index, field) <- nominalFields) yield {
-        val groupCounts = dataFrame.groupBy(new Column(field.name)).count.map(row =>
+        //val groupCounts = dataFrame.groupBy(new Column(field.name)).count() //.map { x => println(x) }
+        //.count.map(row =>
+         // (if (row.isNullAt(0)) "NULL" else row.get(0).toString, row.getLong(1))
+        //)
+        val groupCounts = dataFrame.groupBy(new Column(field.name)).count().rdd.map(row =>
           (if (row.isNullAt(0)) "NULL" else row.get(0).toString, row.getLong(1))
         )
         val cardinality = groupCounts.count
-        val orderedCounts = groupCounts.sortBy(x => x._2, ascending = false)
+        val orderedCounts = groupCounts // .sortBy(x => x._2, ascending = false)
         val mode = orderedCounts.first
         val barTitle = s"Bar of ${field.name}"
         val barPlot = if (cardinality <= 10) {

--- a/core/src/main/scala/de/frosner/dds/core/SparkSqlFunctions.scala
+++ b/core/src/main/scala/de/frosner/dds/core/SparkSqlFunctions.scala
@@ -325,15 +325,13 @@ object SparkSqlFunctions {
       val nominalColumnStatistics = columnStatistics.nominalColumns
       val nominalFields = getNominalFields(dataFrame)
       val nominalServables = for ((index, field) <- nominalFields) yield {
-        //val groupCounts = dataFrame.groupBy(new Column(field.name)).count() //.map { x => println(x) }
-        //.count.map(row =>
-         // (if (row.isNullAt(0)) "NULL" else row.get(0).toString, row.getLong(1))
-        //)
+        //The Spark 2.0 does not support implicit encoding of structure fields other than for 
+        //basic types. The only other way is using a predefined case class.
         val groupCounts = dataFrame.groupBy(new Column(field.name)).count().rdd.map(row =>
           (if (row.isNullAt(0)) "NULL" else row.get(0).toString, row.getLong(1))
         )
         val cardinality = groupCounts.count
-        val orderedCounts = groupCounts // .sortBy(x => x._2, ascending = false)
+        val orderedCounts = groupCounts.sortBy(x => x._2, ascending = false)
         val mode = orderedCounts.first
         val barTitle = s"Bar of ${field.name}"
         val barPlot = if (cardinality <= 10) {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,8 +3,8 @@ import sbt._
 object Dependencies {
 
   // Versions
-  lazy val sparkVersion = "1.5.0"
-  lazy val sprayVersion = "1.3.2"
+  lazy val sparkVersion = "2.1.0"
+  lazy val sprayVersion = "1.3.3"
   lazy val replHelperVersion = "2.0.0"
 
   // Dependencies
@@ -26,7 +26,7 @@ object Dependencies {
   val datasetsDependencies = sparkDependencies ++ scalaTestDependencies
   val webUiDependencies = scalaTestDependencies ++ sparkDependencies ++ Seq(
     "io.spray"           %% "spray-can"     % sprayVersion,
-    "io.spray"           %% "spray-routing" % sprayVersion,
+    "io.spray"           %% "spray-routing-shapeless2" % sprayVersion,
     "io.spray"           %% "spray-caching" % sprayVersion,
     "io.spray"           %% "spray-json"    % "1.3.1",
     "com.typesafe.akka"  %% "akka-actor"    % "2.3.6",

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -15,4 +15,6 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")
 
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.0.1")
+
 run in Compile <<= Defaults.runTask(fullClasspath in Compile, mainClass in (Compile, run), runner in (Compile, run))

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -15,6 +15,4 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")
 
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.0.1")
-
 run in Compile <<= Defaults.runTask(fullClasspath in Compile, mainClass in (Compile, run), runner in (Compile, run))

--- a/web-ui/src/test/scala/de/frosner/dds/webui/servables/ServableJsonProtocolTest.scala
+++ b/web-ui/src/test/scala/de/frosner/dds/webui/servables/ServableJsonProtocolTest.scala
@@ -62,7 +62,8 @@ class ServableJsonProtocolTest extends FlatSpec with Matchers {
           StructField("9", FloatType, true),
           StructField("10", DoubleType, false),
           StructField("11", DoubleType, true),
-          StructField("12", DecimalType.Unlimited, true),
+          //https://github.com/apache/spark/pull/7605/files#diff-89643554d9757dd3e91abff1cc6096c7L134
+          StructField("12", DecimalType.SYSTEM_DEFAULT, true),
           StructField("13", StringType, true),
           StructField("15", BooleanType, false),
           StructField("16", BooleanType, true),


### PR DESCRIPTION
Spark 2.0 deprecates DataFrame against DataSet, with having DataFrame as alias of DataSet[Row]. These changes are needed to make sure the code can be used with spark 2.0. The changes also required moving up with Scala compiler version to 2.11.8 and changes in spray libs appropriately.

Did basic testing with spark 2.0 shell and sbt test.